### PR TITLE
Remove resume link from Heading component

### DIFF
--- a/components/nav/Heading.tsx
+++ b/components/nav/Heading.tsx
@@ -6,9 +6,7 @@ export const Heading = () => {
   return (
     <header className={styles.heading}>
       <MyLinks />
-      <OutlineButton
-        onClick={() => window.open("https://drive.google.com/file/d/13bC2TbZm26201Uzb_HYtNNUkI9uA1GZ3/view?usp=sharing")}
-      >
+      <OutlineButton onClick="">
         Resume
       </OutlineButton>
     </header>


### PR DESCRIPTION
Replace the resume link with an empty string in `components/nav/Heading.tsx`.

* Remove the `onClick` event from the `OutlineButton` component.
* Replace the `onClick` event with an empty string.

