### PR TITLE
Replace the audio link with https://ereqbeats.bandcamp.com/

### DIFF
--- a/components/home/about/About.tsx
+++ b/components/home/about/About.tsx
@@ -20,7 +20,7 @@ export const About = () => {
           <Reveal>
             <p className={styles.aboutText}>
   outside of work, my interests meander in <a href="https://sites.google.com/view/ereqdesign/ervices/esign" style={{textDecoration: 'underline'}}>design</a>, art,
-  and Sound/<a href="https://eqwaves.bandcamp.com/" style={{textDecoration: 'underline'}}>Audio 🔈</a>. you might find me sketching 🎨, or reading cool books 📚. 
+  and Sound/<a href="https://ereqbeats.bandcamp.com/" style={{textDecoration: 'underline'}}>Audio 🔈</a>. you might find me sketching 🎨, or reading cool books 📚. 
 </p>
           </Reveal>
           <Reveal>


### PR DESCRIPTION
Replace the audio link in the "outside of work" section of the about text.

* Change the audio link from `https://eqwaves.bandcamp.com/` to `https://ereqbeats.bandcamp.com/` in `components/home/about/About.tsx`
